### PR TITLE
fix TypeError: 'itertools.imap' object has no attribute 'getitem'

### DIFF
--- a/wlan_client_capability.py
+++ b/wlan_client_capability.py
@@ -82,9 +82,10 @@ def analyze_frame(assoc_req_frame, silent_mode=False, required_client=''):
         # covert tag list in to useable format (decimal list of values)
         dec_array = map(ord, str(dot11_elt_info))
         #hex_array = map(hex, dec_array)
-
+        DA = list()
+        for d in dec_array: DA.append(d)
         # store each tag list in a common tag dictionary
-        dot11_elt_dict[dot11_elt_id] = dec_array
+        dot11_elt_dict[dot11_elt_id] = DA #dec_array
         
         # move to next layer - end of while loop
         dot11_elt = dot11_elt.payload


### PR DESCRIPTION
We were having python exceptions like this:
`TypeError: 'itertools.imap' object has no attribute 'getitem'`

for lines 
```
for mcs_octet in range(3, 7):
        
            mcs_octet_value = dot11_elt_dict[ht_capabilities][mcs_octet]
```

and 

```
    # check if 11ac supported
    if vht_capabilities in dot11_elt_dict.keys():
        
        # Check for number streams supported
        mcs_upper_octet = dot11_elt_dict[vht_capabilities][5]
        mcs_lower_octet = dot11_elt_dict[vht_capabilities][4]
```

I.e. each element from dot11_elt_dict is an itertools.imap object, for example:
`{'59': <itertools.imap object at 0xffff79cb4c10>, '48': <itertools.imap object at 0xffff79cb4950>, '33': <itertools.imap object at 0xffff79cb4890>, '45': <itertools.imap object at 0xffff79cb4a10>, '191': <itertools.imap object at 0xffff79cb4b10>, '36': <itertools.imap object at 0xffff79cb4910>, '1': <itertools.imap object at 0xffff79cb4810>, '0': <itertools.imap object at 0xffff79cb4790>, '127': <itertools.imap object at 0xffff79cb4a90>, '221': <itertools.imap object at 0xffff79cb4b90>, '220': <itertools.imap object at 0xffff79cb4c90>}
`


This fix creates lists needed and puts elements from itertools.imap objects onto these lists, preserving order. 
We can then access the elements with [id] without producing an error.